### PR TITLE
Fix Auth By Going Back to Query Params

### DIFF
--- a/lib/sleet/circle_ci.rb
+++ b/lib/sleet/circle_ci.rb
@@ -10,18 +10,12 @@ module Sleet
       @_token ||= File.read("#{Dir.home}/.circleci.token").strip
     end
 
-    def get(*args, &block)
-      connection.get(*args, &block)
+    def get(url)
+      Faraday.get(url, circleci_token: token)
     end
 
-    def self.get(*args, &block)
-      instance.get(*args, &block)
-    end
-
-    private
-
-    def connection
-      @_connection ||= Faraday.new.tap { |c| c.basic_auth(token, '') }
+    def self.get(url)
+      instance.get(url)
     end
   end
 end

--- a/lib/sleet/circle_ci_branch.rb
+++ b/lib/sleet/circle_ci_branch.rb
@@ -21,7 +21,7 @@ module Sleet
     attr_reader :github_user, :github_repo, :branch
 
     def url
-      "https://circleci.com/api/v1.1/project/github/#{github_user}/#{github_repo}/tree/#{branch}"
+      "https://circleci.com/api/v1.1/project/github/#{github_user}/#{github_repo}/tree/#{branch}?filter=completed"
     end
   end
 end

--- a/lib/sleet/circle_ci_branch.rb
+++ b/lib/sleet/circle_ci_branch.rb
@@ -9,7 +9,7 @@ module Sleet
     end
 
     def builds
-      @_builds ||= JSON.parse(Sleet::CircleCi.get(url, filter: :completed).body)
+      @_builds ||= JSON.parse(Sleet::CircleCi.get(url).body)
     end
 
     def builds_with_artificats

--- a/lib/sleet/circle_ci_build.rb
+++ b/lib/sleet/circle_ci_build.rb
@@ -19,7 +19,7 @@ module Sleet
     attr_reader :github_user, :github_repo
 
     def url
-      "https://circleci.com/api/v1.1/project/github/#{github_user}/#{github_repo}/#{build_num}/artifacts?filter=completed" # rubocop:disable Metrics/LineLength
+      "https://circleci.com/api/v1.1/project/github/#{github_user}/#{github_repo}/#{build_num}/artifacts" # rubocop:disable Metrics/LineLength
     end
   end
 end

--- a/lib/sleet/circle_ci_build.rb
+++ b/lib/sleet/circle_ci_build.rb
@@ -19,7 +19,7 @@ module Sleet
     attr_reader :github_user, :github_repo
 
     def url
-      "https://circleci.com/api/v1.1/project/github/#{github_user}/#{github_repo}/#{build_num}/artifacts" # rubocop:disable Metrics/LineLength
+      "https://circleci.com/api/v1.1/project/github/#{github_user}/#{github_repo}/#{build_num}/artifacts?filter=completed" # rubocop:disable Metrics/LineLength
     end
   end
 end


### PR DESCRIPTION
Revert "Fix auth and add completed query param to the correct place. Use basic auth instead of a query param for auth too"

This reverts commit 8684ce74069701462c729e28313e34aa3a7cc02d.

# Conflicts:
#	lib/sleet/circle_ci.rb