### PR TITLE
Base Version Option

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+gem bump -v $1
+github_changelog_generator -u coreyja -p sleet --future-release v$(bundle exec exe/sleet version --bare)
+g add -A
+g commit --amend --no-edit
+gem release -tp

--- a/lib/sleet/cli.rb
+++ b/lib/sleet/cli.rb
@@ -34,8 +34,13 @@ module Sleet
     end
 
     desc 'version', 'Display the version'
+    option :bare, type: :boolean, default: false
     def version
-      puts "Sleet v#{Sleet::VERSION}"
+      if options[:bare]
+        puts Sleet::VERSION
+      else
+        puts "Sleet v#{Sleet::VERSION}"
+      end
     end
 
     desc 'config', 'Print the config'

--- a/sleet.gemspec
+++ b/sleet.gemspec
@@ -34,6 +34,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor', '~> 0.20.0'
 
   spec.add_development_dependency 'bundler', '~> 1.13'
+  spec.add_development_dependency 'gem-release', '2.0.0.dev.5'
+  spec.add_development_dependency 'github_changelog_generator', '~> 1.14'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rubocop', '~> 0.53.0'


### PR DESCRIPTION
Add the `--bare` option to the version operator and write a quick release script. It relies on the github_changelog_generator and `gem_release` gems.