### PR TITLE
feat: Look at 100 recent builds instead of just 30.

### DIFF
--- a/lib/sleet/branch.rb
+++ b/lib/sleet/branch.rb
@@ -22,7 +22,8 @@ module Sleet
     attr_reader :github_user, :github_repo, :branch, :circle_ci_token
 
     def url
-      "https://circleci.com/api/v1.1/project/github/#{github_user}/#{github_repo}/tree/#{branch}?filter=completed"
+      "https://circleci.com/api/v1.1/project/github/#{github_user}/#{github_repo}/tree/#{branch}" \
+        '?filter=completed&limit=100'
     end
   end
 end

--- a/spec/cli/fetch_spec.rb
+++ b/spec/cli/fetch_spec.rb
@@ -34,7 +34,7 @@ describe 'sleet fetch', type: :cli do
   let(:happy_path_final_file)  { artifact_response }
   let(:stubbed_branch_request) do
     stub_request(:get, %r{https://circleci.com/api/v1.1/project/github/.+/.+/tree/.+})
-      .with(query: { 'circle-token' => 'FAKE_TOKEN', 'filter' => 'completed' })
+      .with(query: { 'circle-token' => 'FAKE_TOKEN', 'filter' => 'completed', 'limit' => '100' })
       .to_return(body: branch_response.to_json)
   end
   let(:stubbed_build_request) do


### PR DESCRIPTION
Hey @coreyja! 👋 thank you for sleet :)

CircleCI limits the number of returned builds to 30 by default, but the
endpoint supports up to 100. When using CircleCI workflows, it's
entirely possible for a single push to trigger more than 30 builds,
which can result in a behavior where sleet will be unable to find some
of the "overflow" builds.

Bumping this to 100 keeps it still possible but much less likely.

A more future-proof solution would be to paginate the builds until a match is found or some artificial limit is reached (probably don’t want this to be infinite), but the existing structure makes this approach a little more difficult to implement without dropping caching. Wonder if you have any thoughts about this.