### PR TITLE
bug: Fix bug in error message when no upstream exists

### DIFF
--- a/.sleet.yml
+++ b/.sleet.yml
@@ -1,3 +1,4 @@
 output_file: 'spec/.rspec_example_statuses'
+username: coreyja
 workflows:
   test: spec/.rspec_example_statuses

--- a/.sleet.yml
+++ b/.sleet.yml
@@ -1,1 +1,3 @@
 output_file: 'spec/.rspec_example_statuses'
+workflows:
+  test: spec/.rspec_example_statuses

--- a/lib/sleet/local_repo.rb
+++ b/lib/sleet/local_repo.rb
@@ -64,7 +64,7 @@ module Sleet
 
     def must_have_an_upstream_branch!
       !current_branch.remote.nil? ||
-        raise(Error, "No upstream branch set for the current branch of #{repo.current_branch_name}")
+        raise(Error, "No upstream branch set for the current branch of #{current_branch_name}")
     end
 
     def upstream_remote_must_be_github!

--- a/sleet.yml
+++ b/sleet.yml
@@ -1,2 +1,0 @@
-workflows:
-  test:spec/.rspec_example_statuses

--- a/sleet.yml
+++ b/sleet.yml
@@ -1,0 +1,2 @@
+workflows:
+  test:spec/.rspec_example_statuses

--- a/spec/cli/fetch_spec.rb
+++ b/spec/cli/fetch_spec.rb
@@ -121,6 +121,14 @@ describe 'sleet fetch', type: :cli do
     end
   end
 
+  context 'when there is no upstream' do
+    before { remove_upstream repo, 'master' }
+
+    it 'runs and outputs the correct error message' do
+      expect_command('fetch').to error_with 'ERROR: No upstream branch set for the current branch of master'
+    end
+  end
+
   context 'when there are no completed builds found for the branch' do
     let(:branch_response) do
       []

--- a/spec/support/git_helper.rb
+++ b/spec/support/git_helper.rb
@@ -21,6 +21,10 @@ module GitHelper
     repo.branches[local_branch].upstream = repo.branches[remote_branch]
   end
 
+  def remove_upstream(repo, local_branch)
+    repo.branches[local_branch].upstream = nil
+  end
+
   private
 
   def add_file_to_index(repo)


### PR DESCRIPTION
Apparently this was an error message that I didn't have speced and missed this at first.
Glad I found it tonight tho!

Spec added for this case!

Also the `.sleet.yml` file here was updated for the most current circleci config, and to take advantage of the new `username` flag we can use to default the username, even if this repo is forked