### PR TITLE
bug: Add support for redirects.

### DIFF
--- a/lib/sleet.rb
+++ b/lib/sleet.rb
@@ -2,6 +2,7 @@
 
 require 'colorize'
 require 'faraday'
+require 'faraday_middleware'
 require 'forwardable'
 require 'json'
 require 'rspec'

--- a/lib/sleet/circle_ci.rb
+++ b/lib/sleet/circle_ci.rb
@@ -5,7 +5,14 @@ require 'singleton'
 module Sleet
   class CircleCi
     def self.get(url, token)
-      Faraday.get(url, 'circle-token' => token)
+      connection.get(url, 'circle-token' => token)
+    end
+
+    def self.connection
+      Faraday.new do |b|
+        b.use FaradayMiddleware::FollowRedirects
+        b.adapter :net_http
+      end
     end
   end
 end

--- a/sleet.gemspec
+++ b/sleet.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'colorize', '~> 0.8.1'
   spec.add_dependency 'faraday', '>= 0.13.1', '< 1.1.0'
+  spec.add_dependency 'faraday_middleware'
   spec.add_dependency 'rspec', '~> 3.0'
   spec.add_dependency 'rugged', '>= 0.26', '< 1.1'
   spec.add_dependency 'terminal-table', '~> 1.8'

--- a/spec/models/sleet/circle_ci_spec.rb
+++ b/spec/models/sleet/circle_ci_spec.rb
@@ -4,11 +4,36 @@ require 'spec_helper'
 
 describe Sleet::CircleCi, type: :model do
   describe '.get' do
-    let!(:stubbed_request) { stub_request(:get, 'http://circleci.com').with(query: { 'circle-token' => 'FAKE_TOKEN' }) }
+    context 'without server redirect' do
+      let!(:stubbed_request) do
+        stub_request(:get, 'http://circleci.com').with(query: { 'circle-token' => 'FAKE_TOKEN' })
+      end
 
-    it 'adds the token as a query param and only reads the token from disk once' do
-      described_class.get 'http://circleci.com', 'FAKE_TOKEN'
-      expect(stubbed_request).to have_been_requested.once
+      it 'adds the token as a query param and only reads the token from disk once' do
+        described_class.get 'http://circleci.com', 'FAKE_TOKEN'
+        expect(stubbed_request).to have_been_requested.once
+      end
+    end
+
+    context 'with server redirect' do
+      let!(:stubbed_redirect) do
+        stub_request(:get, 'http://circleci.com')
+          .with(query: { 'circle-token' => 'FAKE_TOKEN' })
+          .to_return(
+            status: 301,
+            body: 'Your are being redirected',
+            headers: { Location: 'http://s3.amazonaws.com/file' }
+          )
+      end
+      let!(:stubbed_request) do
+        stub_request(:get, 'http://s3.amazonaws.com/file')
+      end
+
+      it 'adds the token as a query param and only reads the token from disk once' do
+        described_class.get 'http://circleci.com', 'FAKE_TOKEN'
+        expect(stubbed_redirect).to have_been_requested.once
+        expect(stubbed_request).to have_been_requested.once
+      end
     end
   end
 end


### PR DESCRIPTION
Sleet stopped working for me some time recently. After running some simple tests, I learned that their API now responds with HTTP redirects when fetching artifacts (at least for my project). This PR adds `faraday_middleware` and updates the connection to follow redirects.