### PR TITLE
bug: CircleCI removed has_artifacts from v1.1 API response

### DIFF
--- a/lib/sleet/branch.rb
+++ b/lib/sleet/branch.rb
@@ -13,10 +13,6 @@ module Sleet
       @builds ||= JSON.parse(Sleet::CircleCi.get(url, circle_ci_token).body)
     end
 
-    def builds_with_artifacts
-      builds.select { |b| b['has_artifacts'] }
-    end
-
     private
 
     attr_reader :github_user, :github_repo, :branch, :circle_ci_token

--- a/lib/sleet/build_selector.rb
+++ b/lib/sleet/build_selector.rb
@@ -29,7 +29,7 @@ module Sleet
     end
 
     def chosen_build_json
-      branch.builds_with_artifacts.find do |b|
+      branch.builds.find do |b|
         b.fetch('workflows', nil)&.fetch('job_name', nil) == job_name
       end
     end

--- a/lib/sleet/build_selector.rb
+++ b/lib/sleet/build_selector.rb
@@ -12,7 +12,7 @@ module Sleet
     end
 
     def validate!
-      must_find_a_build_with_artifacts!
+      must_find_a_build!
       chosen_build_must_have_input_file!
     end
 
@@ -34,14 +34,14 @@ module Sleet
       end
     end
 
-    def must_find_a_build_with_artifacts!
+    def must_find_a_build!
       !chosen_build_json.nil? ||
-        raise(Error, "No builds with artifacts found#{" for job name [#{job_name}]" if job_name}")
+        raise(Error, "No builds found#{" for job name [#{job_name}]" if job_name}")
     end
 
     def chosen_build_must_have_input_file!
       build.artifacts.any? ||
-        raise(Error, "No Rspec example file found in the latest build (##{chosen_build_num}) with artifacts")
+        raise(Error, "No Rspec example file found in the latest build (##{chosen_build_num})")
     end
   end
 end

--- a/spec/cli/fetch_spec.rb
+++ b/spec/cli/fetch_spec.rb
@@ -135,22 +135,7 @@ describe 'sleet fetch', type: :cli do
     end
 
     it 'fails with the correct error message' do
-      expect_command('fetch').to error_with 'ERROR: No builds with artifacts found'
-    end
-  end
-
-  context 'when there are only builds without artifacts' do
-    let(:branch_response) do
-      [
-        {
-          has_artifacts: false,
-          build_num: 23
-        }
-      ]
-    end
-
-    it 'fails with the correct error message' do
-      expect_command('fetch').to error_with 'ERROR: No builds with artifacts found'
+      expect_command('fetch').to error_with 'ERROR: No builds found'
     end
   end
 


### PR DESCRIPTION
It was [removed a month ago](https://discuss.circleci.com/t/upcoming-changes-to-the-has-artifacts-field-from-the-single-job-endpoint-of-the-circleci-api/47190). See the new API structure from [here](https://circleci.com/docs/api/v1/index.html).

```
{
  "vcs_url" : "https://github.com/circleci/mongofinil",
  "build_url" : "https://circleci.com/gh/circleci/mongofinil/22",
  "build_num" : 22,
  "branch" : "master",
  "vcs_revision" : "1d231626ba1d2838e599c5c598d28e2306ad4e48",
  "committer_name" : "Allen Rohner",
  "committer_email" : "arohner@gmail.com",
  "subject" : "Don't explode when the system clock shifts backwards",
  "body" : "", // commit message body
  "why" : "github", // short string explaining the reason the build ran
  "dont_build" : null, // reason why we didn't build, if we didn't build
  "queued_at" : "2013-02-12T21:33:30Z" // time build was queued
  "start_time" : "2013-02-12T21:33:38Z", // time build started
  "stop_time" : "2013-02-12T21:34:01Z", // time build finished
  "build_time_millis" : 23505,
  "username" : "circleci",
  "reponame" : "mongofinil",
  "lifecycle" : "finished", // :queued, :not_run, :not_running, :running or :finished
  "outcome" : "success", // :canceled, :infrastructure_fail, :timedout, :failed, :no_tests or :success
  "status" : "success", // :retried, :canceled, :infrastructure_fail, :timedout, :not_run, :running, :failed, :queued, :not_running, :no_tests, :fixed, :success
  "retry_of" : null, // build_num of the build this is a retry of
  "steps" : [ {
    "name" : "configure the build",
    "actions" : [ {
      "bash_command" : null,
      "run_time_millis" : 1646,
      "start_time" : "2013-02-12T21:33:38Z",
      "end_time" : "2013-02-12T21:33:39Z",
      "name" : "configure the build",
      "exit_code" : null,
      "type" : "infrastructure",
      "index" : 0,
      "status" : "success",
    } ] },

    "name" : "lein2 deps",
    "actions" : [ {
      "bash_command" : "lein2 deps",
      "run_time_millis" : 7555,
      "start_time" : "2013-02-12T21:33:47Z",
      "messages" : [ ],
      "step" : 1,
      "exit_code" : 0,
      "end_time" : "2013-02-12T21:33:54Z",
      "index" : 0,
      "status" : "success",
      "type" : "dependencies",
      "source" : "inference",
      "failed" : null
    } ] },
    "name" : "lein2 trampoline midje",
    "actions" : [ {
      "bash_command" : "lein2 trampoline midje",
      "run_time_millis" : 2310,
      "continue" : null,
      "parallel" : true,
      "start_time" : "2013-02-12T21:33:59Z",
      "name" : "lein2 trampoline midje",
      "messages" : [ ],
      "step" : 6,
      "exit_code" : 1,
      "end_time" : "2013-02-12T21:34:01Z",
      "index" : 0,
      "status" : "failed",
      "timedout" : null,
      "infrastructure_fail" : null,
      "type" : "test",
      "source" : "inference",
      "failed" : true
    } ]
  } ],
  ...
}

```